### PR TITLE
Extracted Metric buckets into standalone class. Fixed Metric bucket calculations to support both Percentage metric buckets and size/time metrics buckets. Update loader for remote pull requests to only include PRs that are after the state date.

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 ORG_NAME=NetManagement
 #USER_NAME=Legend-Rob-Breedt
-START_DATE=2024-06-20
+START_DATE=2024-12-20
 #END_DATE
 REPO_NAME=opengine-platform
 PAGE_SIZE=100;

--- a/src/modules/author/Author.store.ts
+++ b/src/modules/author/Author.store.ts
@@ -12,7 +12,7 @@ export const CSV_HEADERS = [
   {id: 'author', title: 'Author'},
   {id: 'firstActiveDate', title: 'First Active Date'},
   {id: 'lastActiveDate', title: 'Last Active Date'},
-  {id: 'totalCommits', title: 'Total Commits'},
+  {id: 'totalCommits', title: 'Total PR Commits'},
   {id: 'totalPRs', title: 'Total PRs'},
   {id: 'totalPRCommentsGiven', title: 'Total PR Comments Given'},
   {id: 'totalPRReviews', title: 'Total PR Reviews'},
@@ -32,35 +32,49 @@ export const CSV_HEADERS = [
   {id: 'prMaturityPercentages.good', title: 'PR Maturity % Good'},
   {id: 'prMaturityPercentages.fair', title: 'PR Maturity % Fair'},
   {id: 'prMaturityPercentages.needsFocus', title: 'PR Maturity % Needs Focus'},
-  {id: 'codingTimeCounts.elite', title: 'Coding Time Elite'},
-  {id: 'codingTimeCounts.good', title: 'Coding Time Good'},
-  {id: 'codingTimeCounts.fair', title: 'Coding Time Fair'},
-  {id: 'codingTimeCounts.needsFocus', title: 'Coding Time Needs Focus'},
-  {id: 'codingTimePercentages.elite', title: 'Coding Time % Elite'},
-  {id: 'codingTimePercentages.good', title: 'Coding Time % Good'},
-  {id: 'codingTimePercentages.fair', title: 'Coding Time % Fair'},
-  {id: 'codingTimePercentages.needsFocus', title: 'Coding Time % Needs Focus'},
-  {id: 'titleMaturityPercentages.elite', title: 'Title Maturity % Elite'},
-  {id: 'titleMaturityPercentages.good', title: 'Title Maturity % Good'},
-  {id: 'titleMaturityPercentages.fair', title: 'Title Maturity % Fair'},
+  {id: 'codingTimeCounts.elite', title: 'PR Coding Time Elite'},
+  {id: 'codingTimeCounts.good', title: 'PR Coding Time Good'},
+  {id: 'codingTimeCounts.fair', title: 'PR Coding Time Fair'},
+  {id: 'codingTimeCounts.needsFocus', title: 'PR Coding Time Needs Focus'},
+  {id: 'codingTimePercentages.elite', title: 'PR Coding Time % Elite'},
+  {id: 'codingTimePercentages.good', title: 'PR Coding Time % Good'},
+  {id: 'codingTimePercentages.fair', title: 'PR Coding Time % Fair'},
+  {id: 'codingTimePercentages.needsFocus', title: 'PR Coding Time % Needs Focus'},
+  {id: 'titleMaturityPercentages.elite', title: 'PR Title Maturity % Elite'},
+  {id: 'titleMaturityPercentages.good', title: 'PR Title Maturity % Good'},
+  {id: 'titleMaturityPercentages.fair', title: 'PR Title Maturity % Fair'},
   {
     id: 'titleMaturityPercentages.needsFocus',
-    title: 'Title Maturity % Needs Focus',
+    title: 'PR Title Maturity % Needs Focus',
   },
-  {id: 'titleMaturityCounts.elite', title: 'Title Counts Elite'},
-  {id: 'titleMaturityCounts.good', title: 'Title Counts Good'},
-  {id: 'titleMaturityCounts.fair', title: 'Title Counts Fair'},
-  {id: 'titleMaturityCounts.needsFocus', title: 'Title Counts Needs Focus'},
-  {id: 'prCommentGivenMaturityPercentages.elite', title: 'Comments % Elite'},
-  {id: 'prCommentGivenMaturityPercentages.good', title: 'Comments % Good'},
-  {id: 'prCommentGivenMaturityPercentages.fair', title: 'Comments % Fair'},
+  {id: 'titleMaturityCounts.elite', title: 'PR Title Counts Elite'},
+  {id: 'titleMaturityCounts.good', title: 'PR Title Counts Good'},
+  {id: 'titleMaturityCounts.fair', title: 'PR Title Counts Fair'},
+  {id: 'titleMaturityCounts.needsFocus', title: 'PR Title Counts Needs Focus'},
+  {id: 'prCommitCommentMaturityCount.elite', title: 'PR Commit Comment Elite'},
+  {id: 'prCommitCommentMaturityCount.good', title: 'PR Commit Comment Good'},
+  {id: 'prCommitCommentMaturityCount.fair', title: 'PR Commit Comment Fair'},
+  {
+    id: 'prCommitCommentMaturityCount.needsFocus',
+    title: 'PR Commit Comment Needs Focus',
+  },
+  {id: 'prCommitCommentMaturityPercentages.elite', title: 'PR Commit Comment % Elite'},
+  {id: 'prCommitCommentMaturityPercentages.good', title: 'PR Commit Comment % Good'},
+  {id: 'prCommitCommentMaturityPercentages.fair', title: 'PR Commit Comment % Fair'},
+  {
+    id: 'prCommitCommentMaturityPercentages.needsFocus',
+    title: 'PR Commit Comment % Needs Focus',
+  },
+  {id: 'prCommentGivenMaturityPercentages.elite', title: 'PR Comments Given % Elite'},
+  {id: 'prCommentGivenMaturityPercentages.good', title: 'PR Comments Given % Good'},
+  {id: 'prCommentGivenMaturityPercentages.fair', title: 'PR Comments Given % Fair'},
   {
     id: 'prCommentGivenMaturityPercentages.needsFocus',
     title: 'Comments % Needs Focus',
   },
-  {id: 'prCommentGivenMaturityCounts.elite', title: 'Comments Counts Elite'},
-  {id: 'prCommentGivenMaturityCounts.good', title: 'Comments Counts Good'},
-  {id: 'prCommentGivenMaturityCounts.fair', title: 'Comments Counts Fair'},
+  {id: 'prCommentGivenMaturityCounts.elite', title: 'PR Comments Given Counts Elite'},
+  {id: 'prCommentGivenMaturityCounts.good', title: 'PR Comments Given Counts Good'},
+  {id: 'prCommentGivenMaturityCounts.fair', title: 'PR Comments Given Counts Fair'},
   {
     id: 'prCommentGivenMaturityCounts.needsFocus',
     title: 'Comments Counts Needs Focus',
@@ -304,6 +318,40 @@ export class AuthorStore {
                 row['prCommentGivenMaturityCounts.needsFocus'],
                 10,
               );
+
+            author.prCommitCommentMaturityCount.elite = parseInt(
+              row['prCommitCommentMaturityCount.elite'],
+              10
+            );
+            author.prCommitCommentMaturityCount.good = parseInt(
+              row['prCommitCommentMaturityCount.good'],
+              10,
+            );
+            author.prCommitCommentMaturityCount.fair = parseInt(
+              row['prCommitCommentMaturityCount.fair'],
+              10,
+            );
+            author.prCommitCommentMaturityCount.needsFocus = parseInt(
+              row['prCommitCommentMaturityCount.needsFocus'],
+              10,
+            );
+            author.prCommitCommentMaturityPercentages.elite = parseInt(
+              row['prCommitCommentMaturityPercentages.elite'],
+              10,
+            );
+            author.prCommitCommentMaturityPercentages.good = parseInt(
+              row['prCommitCommentMaturityPercentages.good'],
+              10,
+            );
+            author.prCommitCommentMaturityPercentages.fair = parseInt(
+              row['prCommitCommentMaturityPercentages.fair'],
+              10,
+            );
+            author.prCommitCommentMaturityPercentages.needsFocus = parseInt(
+              row['prCommitCommentMaturityPercentages.needsFocus'],
+              10,
+            );
+
             authors[row.author] = author;
           }
         })
@@ -379,6 +427,22 @@ export class AuthorStore {
           author.prCommentGivenMaturityCounts.fair,
         'prCommentGivenMaturityCounts.needsFocus':
           author.prCommentGivenMaturityCounts.needsFocus,
+        'prCommitCommentMaturityCount.elite':
+          author.prCommitCommentMaturityCount.elite,
+        'prCommitCommentMaturityCount.good':
+          author.prCommitCommentMaturityCount.good,
+        'prCommitCommentMaturityCount.fair':
+          author.prCommitCommentMaturityCount.fair,
+        'prCommitCommentMaturityCount.needsFocus':
+          author.prCommitCommentMaturityCount.needsFocus,
+        'prCommitCommentMaturityPercentages.elite':
+          author.prCommitCommentMaturityPercentages.elite,
+        'prCommitCommentMaturityPercentages.good':
+          author.prCommitCommentMaturityPercentages.good,
+        'prCommitCommentMaturityPercentages.fair':
+          author.prCommitCommentMaturityPercentages.fair,
+        'prCommitCommentMaturityPercentages.needsFocus':
+          author.prCommitCommentMaturityPercentages.needsFocus
       });
     }
 

--- a/src/modules/author/Author.ts
+++ b/src/modules/author/Author.ts
@@ -1,5 +1,5 @@
 import {PullRequest} from '../pullrequest/PullRequest';
-import {COMMENT_MATURITY_LENGTH} from '../../constants';
+import { calculateCommentTitleMaturity, MetricBuckets } from "../metricbuckets/MetricBuckets.types";
 
 export interface Author {
   author: string;
@@ -13,73 +13,18 @@ export interface Author {
   //METRICS ARE ONLY INCLUDED FOR MERGED PULL REQUESTS
   //Counts are the total number of metrics that fall into each bracket.
   //Percentages are effectively the counts of each bucket divided by the total count of all of them.
-  codingTimeCounts: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  }; //Elite < 1 hour, Good <4 hours, Fair <23 hours, NeedFocus >23 hours
-  codingTimePercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  prCommitCommentMaturityCount: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  }; //Strength of an Authors commit comments
-  prCommitCommentMaturityPercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  prCommentGivenMaturityCounts: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  }; //Strength of PR Commenters comments given on PRs.
-  prCommentGivenMaturityPercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  prSizeCounts: {elite: number; good: number; fair: number; needsFocus: number}; //Number of PRs that PR Size lines of code:Elite <85 Good <138 -> Fair <209 ->NeedsFocus
-  prSizePercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  prMaturityCounts: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  }; //Elite > 91%, Good > 84$, Fair >= 77%, NeedFocus < 77%
-  prMaturityPercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  titleMaturityCounts: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
-  titleMaturityPercentages: {
-    elite: number;
-    good: number;
-    fair: number;
-    needsFocus: number;
-  };
+  codingTimeCounts: MetricBuckets; //Elite < 1 hour, Good <4 hours, Fair <23 hours, NeedFocus >23 hours
+  codingTimePercentages:MetricBuckets;
+  prCommitCommentMaturityCount: MetricBuckets; //Strength of an Authors commit comments
+  prCommitCommentMaturityPercentages: MetricBuckets;
+  prCommentGivenMaturityCounts: MetricBuckets; //Strength of PR Commenters comments given on PRs.
+  prCommentGivenMaturityPercentages: MetricBuckets;
+  prSizeCounts: MetricBuckets; //Number of PRs that PR Size lines of code:Elite <85 Good <138 -> Fair <209 ->NeedsFocus
+  prSizePercentages: MetricBuckets;
+  prMaturityCounts: MetricBuckets; //Elite > 91%, Good > 84$, Fair >= 77%, NeedFocus < 77%
+  prMaturityPercentages: MetricBuckets;
+  titleMaturityCounts: MetricBuckets;
+  titleMaturityPercentages: MetricBuckets;
 }
 
 export function createAuthor(authorName: string): Author {
@@ -92,91 +37,39 @@ export function createAuthor(authorName: string): Author {
     totalPRCommentsGiven: 0,
     totalPRReviews: 0,
 
-    prSizeCounts: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prSizePercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prMaturityCounts: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prMaturityPercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    codingTimeCounts: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    codingTimePercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    titleMaturityPercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prCommentGivenMaturityPercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    titleMaturityCounts: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prCommentGivenMaturityCounts: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prCommitCommentMaturityCount: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
-    prCommitCommentMaturityPercentages: {
-      elite: 0,
-      good: 0,
-      fair: 0,
-      needsFocus: 0,
-    },
+    prSizeCounts: new MetricBuckets(),
+    prSizePercentages: new MetricBuckets(),
+    prMaturityCounts: new MetricBuckets(),
+    prMaturityPercentages: new MetricBuckets(),
+    codingTimeCounts: new MetricBuckets(),
+    codingTimePercentages: new MetricBuckets(),
+    titleMaturityPercentages:new MetricBuckets(),
+    prCommentGivenMaturityPercentages: new MetricBuckets(),
+    titleMaturityCounts: new MetricBuckets(),
+    prCommentGivenMaturityCounts: new MetricBuckets(),
+    prCommitCommentMaturityCount: new MetricBuckets(),
+    prCommitCommentMaturityPercentages: new MetricBuckets(),
   };
 }
 
 function updateAuthorBucketMetrics(
-  metricCounts: any,
-  metricPercentages: any,
+  metricCounts: MetricBuckets,
+  metricPercentages: MetricBuckets,
   value: number,
   thresholds: number[],
+  percentage?: boolean
 ) {
-  if (value < thresholds[0]) metricCounts.elite++;
-  else if (value < thresholds[1]) metricCounts.good++;
-  else if (value < thresholds[2]) metricCounts.fair++;
-  else metricCounts.needsFocus++;
+  if (percentage) {
+    if (value > thresholds[0]) metricCounts.elite++;
+    else if (value > thresholds[1]) metricCounts.good++;
+    else if (value > thresholds[2]) metricCounts.fair++;
+    else metricCounts.needsFocus++;
+  } else {
+    if (value < thresholds[0]) metricCounts.elite++;
+    else if (value < thresholds[1]) metricCounts.good++;
+    else if (value < thresholds[2]) metricCounts.fair++;
+    else metricCounts.needsFocus++;
+  }
 
   const total =
     metricCounts.elite +
@@ -237,12 +130,14 @@ export function calculateAuthorMetrics(
         author.prMaturityPercentages,
         pr.maturity,
         [91, 84, 77],
+        true
       );
     updateAuthorBucketMetrics(
       author.titleMaturityCounts,
       author.titleMaturityPercentages,
       pr.titleMaturity,
-      [100, 75, 50],
+      [75, 50, 25],
+      true
     );
 
     for (const commit of pr.commits) {
@@ -250,8 +145,9 @@ export function calculateAuthorMetrics(
         updateAuthorBucketMetrics(
           author.prCommitCommentMaturityCount,
           author.prCommitCommentMaturityPercentages,
-          calculateCommentTitleMaturity(commit.title),
-          [100, 75, 50],
+          MetricBuckets.calculateCommentTitleMaturity(commit.title),
+          [75, 50, 25],
+          true
         );
         author.totalCommits++;
       }
@@ -270,15 +166,17 @@ function calculateAuthorCommentMetrics(
   const commentAuthors: Record<string, Author> = {};
   for (const comment of pr.comments) {
     if (comment.author != pr.author) {
-      if (authorRecords[comment.author] == null)
+      if (authorRecords[comment.author] == null) {
         authorRecords[comment.author] = createAuthor(comment.author);
+      }
       authorRecords[comment.author].totalPRCommentsGiven++;
       updateAuthorBucketMetrics(
         authorRecords[comment.author].prCommentGivenMaturityCounts,
         authorRecords[comment.author].prCommentGivenMaturityPercentages,
-        calculateCommentTitleMaturity(comment.body),
-        [100, 75, 50],
+        MetricBuckets.calculateCommentTitleMaturity(comment.body),
+        [75, 50, 25],true
       );
+      console.log("Updated author's comment metrics:",comment.author, authorRecords[comment.author].prCommitCommentMaturityCount);
       commentAuthors[comment.author] = authorRecords[comment.author];
     }
   }
@@ -287,13 +185,4 @@ function calculateAuthorCommentMetrics(
   }
 }
 
-function calculateCommentTitleMaturity(comment: string) {
-  return (
-    Number(
-      Math.max(
-        0.1,
-        1 - comment.length / Number(COMMENT_MATURITY_LENGTH),
-      ).toFixed(2),
-    ) * 100
-  );
-}
+

--- a/src/modules/metricbuckets/MetricBuckets.types.ts
+++ b/src/modules/metricbuckets/MetricBuckets.types.ts
@@ -1,0 +1,21 @@
+import { COMMENT_MATURITY_LENGTH } from "../../constants";
+
+export class MetricBuckets {
+  public elite: number;
+  public good: number;
+  public fair: number;
+  public needsFocus: number;
+
+  constructor() {
+    this.elite = 0;
+    this.good = 0;
+    this.fair = 0;
+    this.needsFocus = 0;
+  }
+
+  static calculateCommentTitleMaturity(comment: string, MATURITY_LENGTH?: string) {
+    if (!MATURITY_LENGTH) MATURITY_LENGTH = COMMENT_MATURITY_LENGTH;
+    return Number(Number(comment.length / Number(MATURITY_LENGTH)).toFixed(2))*100;
+  }
+
+}


### PR DESCRIPTION
This PR fixes a number of issues around calcuation of metric buckets which was putting all the results of percentage type buckets into elite.